### PR TITLE
refactor: rendering pages as batch

### DIFF
--- a/src/node/build/build.ts
+++ b/src/node/build/build.ts
@@ -106,24 +106,30 @@ export async function build(
         }
       }
 
-      await Promise.all(
-        ['404.md', ...siteConfig.pages]
-          .map((page) => siteConfig.rewrites.map[page] || page)
-          .map((page) =>
-            renderPage(
-              render,
-              siteConfig,
-              page,
-              clientResult,
-              appChunk,
-              cssChunk,
-              assets,
-              pageToHashMap,
-              metadataScript,
-              additionalHeadTags
+      const pages = ['404.md', ...siteConfig.pages]
+      const batchSize = 100
+
+      for (let i = 0; i < pages.length; i += batchSize) {
+        const batch = pages.slice(i, i + batchSize)
+        await Promise.all(
+          batch
+            .map((page) => siteConfig.rewrites.map[page] || page)
+            .map((page) =>
+              renderPage(
+                render,
+                siteConfig,
+                page,
+                clientResult,
+                appChunk,
+                cssChunk,
+                assets,
+                pageToHashMap,
+                metadataScript,
+                additionalHeadTags
+              )
             )
-          )
-      )
+        )
+      }
     })
 
     // emit page hash map for the case where a user session is open


### PR DESCRIPTION
To overcome this challenge, I implemented a batch processing approach to handle the rendering of pages in smaller batches (batchSize). The original code processed all pages simultaneously, leading to excessive memory consumption and build failures for large datasets. By dividing the rendering tasks into manageable batches, we significantly reduced memory usage during the build process.